### PR TITLE
Add support for ioniq5 and ev6

### DIFF
--- a/autopi_cars.json
+++ b/autopi_cars.json
@@ -3,5 +3,9 @@
   "chevy:bolt:20:66": {"wake_pid": "Mode=22, Code=2414, Header=7E1"},
   "opel:ampera-e:17:60:other": {"wake_pid": "Mode=22, Code=2414, Header=7E1"},
   "hyundai:kona:19:64:other": {"wake_pid": "Unknown"},
-  "hyundai:kona:19:39:other": {"wake_pid": "Unknown"}
+  "hyundai:kona:19:39:other": {"wake_pid": "Unknown"},
+  "hyundai:ioniq5:22:58": {"wake_pid": "Unknown"},
+  "hyundai:ioniq5:22:74": {"wake_pid": "Unknown"},
+  "kia:ev6:22:58": {"wake_pid": "Unknown"},
+  "kia:ev6:22:77": {"wake_pid": "Unknown"}
 }

--- a/my_abrp.py
+++ b/my_abrp.py
@@ -490,6 +490,8 @@ class HKMC(CarOBD):
         'speed':      "220,100,bytes_to_int(message.data[32:33]),7B3",
         'kwh_charged':"220,101,(bytes_to_int(message.data[41:45]))/10.0,7E4",
       }
+      if self.tc.model in ['ev6', 'ioniq5']:
+        self.pids['is_charging'] = "220,101,int({10:7}),7E4"
     elif int(self.tc.year) < 19:
       # older cars
       self.pids = {


### PR DESCRIPTION
This should add support for ioniq5 and ev6. The pids are basically the same but with a change for the is_carging boolean.